### PR TITLE
miner: remove special handling of hnspool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ registered:
 **stratum host**: stratum-us.hnspool.com
 **stratum_port**: 3001
 
-**username**: hnspool_registered_username
-**password**: hnspool_registered_password
+**username**: hnspool_registered_username.workerName or address.workerName
+**password**: anything
 
 <a id="advancedOptions"></a>
 ## Advanced Options:


### PR DESCRIPTION
Removing Hnspool special stratum handling. Commit message explains most of the reasoning behind this: 

Commit Message: 
```
Previously HNSPool supported multiple stratum protocols for HNS in an
attempt to help build a better stratum protocol. Due to lack of adoption
of this different spec, we have all but dropped support for the spec.
While technically it should work, we can't promise perfect operation as
most focus is spent on the more standard spec used by all other pools.

This commit simply removes the special support for HNSPool as we fully
support the more generic stratum spec. There is still likely a future in
which we implement this new spec, but it's not likely enough to warrant
keeping this special handling in handyminer.
```

Seems like my automatic linter also removed some Tab characters on empty lines, which is desirable, but if it's mucking up the diff I can happily remove those edits.