### PR TITLE
miner: add client to subscribe message

### DIFF
--- a/miner/HandyMiner_GoldShell.js
+++ b/miner/HandyMiner_GoldShell.js
@@ -73,15 +73,15 @@ class HandyMiner {
       if(this.config.mode == 'pool'){
         //check for difficulty
         if(typeof this.config.poolDifficulty != "undefined"){
-          
+
           this.poolDifficulty = parseFloat(this.config.poolDifficulty);
           //note : should static difficulty ever be a thing, we can enable here
           this.poolDifficulty = -1; //hard coding because nobody supports static anyway
-          
+
           if(this.poolDifficulty < 2048 && this.poolDifficulty >= 0 && this.config.host.indexOf('6block') >= 0){
             //6block pool min diff is 1024 (4)
             this.poolDifficulty = 2048;
-            
+
             if(process.env.HANDYRAW){
               process.stdout.write(JSON.stringify({type:'stratumLog',data:'setting 6block pool min difficulty at 2048'})+'\n');
             }
@@ -92,7 +92,7 @@ class HandyMiner {
           }
           else if(this.poolDifficulty < 512 && this.poolDifficulty >= 0 && this.config.host.indexOf('hnspool') >= 0){
             this.poolDifficulty = 512;
-            
+
             if(process.env.HANDYRAW){
               process.stdout.write(JSON.stringify({type:'stratumLog',data:'setting hnspool pool min difficulty at 512'})+'\n');
             }
@@ -133,12 +133,12 @@ class HandyMiner {
         this.host = this.host.split(':')[0];
       }
     }
-    
+
     this.port = config.port || '3008';
     this.gpuListString = config.gpus || '-1';
     this.asics = config.asics || '-1';
     this.stratumUser = config.stratum_user || 'earthlab';
-    
+
     this.stratumUserLocal = this.stratumUser;
     this.stratumPass = config.stratum_pass || 'earthlab'; //going to think this might be wallet?
     this.platformID = config.gpu_platform || '0';
@@ -167,7 +167,7 @@ class HandyMiner {
       process.env.TEMP = '/tmp';
     }
 
-    
+
     if(process.argv[2] && process.argv[3] && process.argv[4]){
 
       /*this.gpuListString = process.argv[2];
@@ -218,7 +218,7 @@ class HandyMiner {
       }
     }
 
-    
+
     /*if(process.argv[13]){
       //pool difficulty
       this.poolDifficulty = parseInt(process.argv[13]);
@@ -318,7 +318,7 @@ class HandyMiner {
       //this is some admin user i think?
       const serverAdminPass = stratumUsersFromArgs.serverPass;
       if(this.config.mode == 'pool' && this.host.toLowerCase().indexOf('hnspool') >= 0){
-        //format connection messages for hnspool        
+        //format connection messages for hnspool
         this.server.write(JSON.stringify({"id":this.targetID,"method":"authorize","params":[stratumUser,stratumPass, "handy-miner-v0.0.0"]})+"\n");
         //this.server.write(JSON.stringify({"id":this.registerID,"method":"subscribe","params":["handy-miner-v0.0.0", this.sid]})+"\n");
       }
@@ -335,12 +335,12 @@ class HandyMiner {
           this.server.write(JSON.stringify({"id":this.registerID,"method":"mining.subscribe","params":[]})+"\n");
         }
         else{
-          this.server.write(JSON.stringify({"id":this.registerID,"method":"mining.subscribe","params":['user agent/version']})+"\n");
+          this.server.write(JSON.stringify({"id":this.registerID,"method":"mining.subscribe","params":["handy-miner-v1.0.0"]})+"\n");
         }
       }
 
 
-      
+
       //process.stdin.setRawMode(true);
     });
     let ongoingResp = '';
@@ -348,7 +348,7 @@ class HandyMiner {
       //if(!this.isMGoing){
         this.hasConnectionError = false;
         //console.log('server response',response.toString('utf8'));
-        
+
         ongoingResp = this.parseServerResponse(response,ongoingResp,true);
       //}
 
@@ -466,12 +466,12 @@ class HandyMiner {
               resolve();
             }
           });
-          
+
           //
         })
       })
     }).then(()=>{
-      
+
       if(callback){
         callback();
       }
@@ -493,7 +493,7 @@ class HandyMiner {
     //MASSIVELY ANNOYING TODO: ELIMINATE TRAILING COMMA IN BIG RESPONSES FROM STRATUM
     let resp = response.toString('utf8').split('\n');
     let didParse = true;
-    
+
     //take care to check for empty lines
     resp = resp.filter((d)=>{
       return d.length > 1;
@@ -592,7 +592,7 @@ class HandyMiner {
             setTimeout(()=>{
               this.startSocket();
             },20000);
-          } 
+          }
         break;
         case 'subscribe':
           this.sid = d.result;
@@ -627,7 +627,7 @@ class HandyMiner {
               this.poolDifficulty = parseFloat(d.params) * 256;
             }
             else{
-              this.poolDifficulty = parseFloat(d.params[0]) * 256;  
+              this.poolDifficulty = parseFloat(d.params[0]) * 256;
             }
 
             if(this.config.mode == 'pool' && (lastDiff != this.poolDifficulty)){
@@ -640,7 +640,7 @@ class HandyMiner {
                 }
             }
           }
-        
+
         break;
       }
       if(d.error != null && typeof d.method == "undefined"){
@@ -853,7 +853,7 @@ class HandyMiner {
               //we should let the dashboard know about the share
                 this.displayWin(d,true);
                 //this.generateWork(); //dont need this
-              
+
             }
           }
 				break;
@@ -921,7 +921,7 @@ class HandyMiner {
         else{
           console.log('HANDY:: \x1b[36mCONFIRMATION RESPONSE!\x1b[0m',d);
         }
-        
+
       }
 
     }
@@ -981,7 +981,7 @@ class HandyMiner {
         this.generateWork(asicID);
       })
     }
-    
+
   }
 	getBlockHeader(nonce2Override){
 		const _this = this;
@@ -1011,7 +1011,7 @@ class HandyMiner {
     let version;
     let bits;
     let time;
-    
+
     if(this.IS_HNSPOOLSTRATUM && !this.isMGoing){
       //support HNSPOOL response format
       reservedRoot = response.params[3]; //these are prob all zeroes rn but here for future use
@@ -1043,12 +1043,12 @@ class HandyMiner {
       }
       else{
         this.server.destroy();
-        
+
       }
       //restart hnspool connection
       this.handleStratumReconnect();
-        
-      return;  
+
+      return;
     }
 
     let bt = {};//new template.BlockTemplate();
@@ -1067,7 +1067,7 @@ class HandyMiner {
     else{
       //TODO: When hstratum finally sends out .maskHash() values add here
       //like this:: bt.maskHash = Buffer.from(maskHash, 'hex');
-      //should be replaced in hstratum .toJSON output array 
+      //should be replaced in hstratum .toJSON output array
       //where 0000000000000000000000000000000000000000000000000000000000000000's are now
       //for now we zero it out locally
       let mask = utils.ZERO_HASH;
@@ -1102,12 +1102,12 @@ class HandyMiner {
     let nonce = Buffer.alloc(4, 0x00);
 
     const exStr = Buffer.from(this.nonce1+nonce2,'hex');
-    
+
     let extraNonce = Buffer.alloc(utils.NONCE_SIZE, 0x00);//utils.ZERO_NONCE;
     for(var i=0;i<exStr.length;i++){
       extraNonce[i] = exStr[i];
     }
-    
+
     bt.extraNonce = extraNonce;
 
     const hdrRaw = utils.getRawHeader(0, bt);
@@ -1115,7 +1115,7 @@ class HandyMiner {
     const pad8 = utils.padding(8,bt.prevBlock,bt.treeRoot);
     const pad32 = utils.padding(32,bt.prevBlock,bt.treeRoot);
     const targetString = bt.target.toString('hex');
-    
+
     return {
       jobID:jobID,
       time:time,
@@ -1156,7 +1156,7 @@ class HandyMiner {
                      //                        |8A02| = frequency = 650, default hs1
                      //                        |A302| = 675
                      //                        |BC02| = 700
-                     //                        |    |       41 = temp target = 65C                         
+                     //                        |    |       41 = temp target = 65C
                      //                        |    |       5A = temp target = 90C
           let params = 'A53C96A21010000000A2EE028A02040000004169C35A'; //default hs1 params
           if(asicInfo.modelName.indexOf('Plus') >= 0){
@@ -1190,7 +1190,7 @@ class HandyMiner {
             //nothing useful here, hashRate is empty: let bufferStats = new Buffer.from('A53C96A4100600000069C35A','hex');
             this.asicWorkers[asicID].write(bufferStats,(err)=>{
               //console.log('poll device info',err);
-            
+
             });
             //refresh jobs every 20s to prevent nonce overflow
             if(process.env.HANDYMINER_GUI_NODE_EXEC){
@@ -1204,7 +1204,7 @@ class HandyMiner {
               //this.refreshAllJobs(true);
               this.generateWork(asicID,true);
             }
-            
+
           },timeInterval);
           this.asicInfoLookupIntervals[asicID] = sI;
         }
@@ -1224,7 +1224,7 @@ class HandyMiner {
         let justFinished = this.asicWorkQueueNext[asicID] - 1;
         this.gpuDeviceBlocks[justFinished+'_'+asicID] = this.nextDeviceBlocks[justFinished+'_'+asicID];
         this.queueNextWork(asicID);
-        
+
       break;
       case 0x51:
         //console.log('nonce received');
@@ -1239,10 +1239,10 @@ class HandyMiner {
       	}
 	      //console.log('nonce solved',asicNonceResponse.jobID,asicID,workSolved);
         this.submitASICNonce(asicNonceResponse,asicID,workSolved);
-        
+
       break;
     }
-    
+
   }
   submitASICNonce(response,asicID,lastJob){
     let submission = [];
@@ -1270,7 +1270,7 @@ class HandyMiner {
         }
         else{
           //solo stratum expects length == 16
-          submission.push('00000000'+response.nonce.slice(8,16));  
+          submission.push('00000000'+response.nonce.slice(8,16));
         }
         submission.push(lastJob.work.blockTemplate.mask.toString('hex'));
         submitMethod = 'mining.submit';
@@ -1281,7 +1281,7 @@ class HandyMiner {
       //mismatched work err
       return;
     }
-    
+
     /*if(typeof lastJob != "undefined"){
       delete _this.workByHeaders[jobHeader];
     }*/
@@ -1316,7 +1316,7 @@ class HandyMiner {
     }
     this.isSubmitting = true; //block
 
-  
+
   }
   queueNextWork(asicID){
     //console.log('to queue next',asicID);
@@ -1385,7 +1385,7 @@ class HandyMiner {
         }
       });
       let totalAverageHashrate = sumAverages / sumAverageLength;
-    
+
     }*/
 
     Object.keys(this.asicWorkers).map((asicID,asicI)=>{
@@ -1406,7 +1406,7 @@ class HandyMiner {
         let hourlyAvg = this.asicJobHashrates[asicID+'_'+workerID].last200Rates.reduce((a,b)=>{
           return a+b;
         })/this.asicJobHashrates[asicID+'_'+workerID].last200Rates.length;
-        
+
         //dont display negative #s
         if(hourlyAvg < 0){
           hourlyAvg = 0;
@@ -1434,7 +1434,7 @@ class HandyMiner {
         perWorkerRateNow[asicID][workerID] = hashRatePerSecond;
 
         sumTotal++;
-        sumRateNow += hashRatePerSecond; 
+        sumRateNow += hashRatePerSecond;
         sumRateAvg += hourlyAvg;
       }
       if(typeof this.asicStats[asicID] == "undefined"){
@@ -1462,7 +1462,7 @@ class HandyMiner {
         for(let workerID=1;workerID<=workDepth;workerID++){
           let wNow = 0;
           let wAvg = 0;
-          
+
           if(typeof perWorkerRateNow[asicID][workerID] != "undefined"){
             wNow = Math.round(perWorkerRateNow[asicID][workerID]*100)/100;
             wAvg = Math.round(perWorkerRateAvg[asicID][workerID]*100)/100;
@@ -1497,20 +1497,20 @@ class HandyMiner {
         }
         process.stdout.write(JSON.stringify(asicData)+'\n')
       }
-      
+
     });
 
 
   }
   writeWorkToASIC(asicID,workerID,work){
-    
+
     this.asicWorkQueueNext[asicID] = workerID+1;
     let serialConn = this.asicWorkers[asicID];
     if(typeof serialConn == "undefined"){
       return;
     }
     //console.log('early on header time is',work.work.header.slice(4,12).toString('hex'));
-    
+
     let tgt = work.work.target.slice(0,8).reverse().toString('hex').slice(0,16).toUpperCase() ;
     //target should be little endian
     let timestamp = new Buffer.from(work.work.header.slice(4,12)).toString('hex').slice(0,8);
@@ -1532,7 +1532,7 @@ class HandyMiner {
       this.asicJobHashrates[asicID+'_'+workerID].last = new Buffer.from(timestamp,'hex').reverse().toString('hex')+'00000000';
       this.asicJobHashrates[asicID+'_'+workerID].lastMeasured = new Date().getTime();
     }
-    
+
     work.work.header[4] = 0;
     work.work.header[5] = 0;
     work.work.header[6] = 0;
@@ -1554,24 +1554,24 @@ class HandyMiner {
     data += '0'+workerID;
     data += work.work.header.toString('hex').toUpperCase();
     data += '69C35A';
-    
+
     serialConn.write(new Buffer.from(data,'hex'),err=>{
-      this.gpuDeviceBlocks[workerID+'_'+asicID] = this.nextDeviceBlocks[workerID+'_'+asicID];    
+      this.gpuDeviceBlocks[workerID+'_'+asicID] = this.nextDeviceBlocks[workerID+'_'+asicID];
     })
   }
   spawnASICWorker(asicID,asicArrayI){
-    
+
     if(asicID != '-1'){
       //known connection
       const conn = new SerialPort(asicID,{autoOpen:true});
       this.asicWorkers[asicID] = conn;
       this.asicShares[asicID] = {valid:0,invalid:0};
       conn.write(new Buffer.from('A53C96A4100600000069C35A','hex'),e=>{
-        
+
       })
       conn.on('data',data=>{
         this.handleAsicMessage(data,asicID);
-        
+
       })
       conn.on('error',d=>{
         //needs to be present on mac to make close fire?
@@ -1616,16 +1616,16 @@ class HandyMiner {
       })
     }
     else{
-      
+
       this.listAsics();
 
     }
-    
+
   }
   listenForNewHardware(){
     setTimeout(()=>{
-      this.listAsics();  
-      this.listenForNewHardware();  
+      this.listAsics();
+      this.listenForNewHardware();
     },2000);
   }
   listAsics(){
@@ -1659,9 +1659,9 @@ class HandyMiner {
         return Object.keys(this.asicNames).indexOf(p.path) == -1;
       });
       pollCount = ports.length;
-      
+
       ports.map(port=>{
-        
+
         let p = port.path;
         let conn = new SerialPort(p,{autoOpen:true},err=>{
           if(err){
@@ -1703,11 +1703,11 @@ class HandyMiner {
         this.finishCheck(hasPolled,pollCount,asics);
       });*/
       this.finishCheck(hasPolled,pollCount,asics);
-      
+
       //console.log('error listing ports',err);
     })
 
-    
+
   }
   finishCheck(hasPolled,pollCount,asics){
     if(hasPolled < pollCount){
@@ -1723,11 +1723,11 @@ class HandyMiner {
         process.stdout.write(JSON.stringify(regResp)+'\n');
       }
       else{
-        console.log('\x1b[31mERROR: NO GOLDSHELL HS1 FOUND\x1b[0m') 
+        console.log('\x1b[31mERROR: NO GOLDSHELL HS1 FOUND\x1b[0m')
         console.log('PLEASE VERIFY THE USB IS PLUGGED IN AND THE ASIC HAS AC POWER')
-        //console.log('SEE https://github.com/HandyMiner/HandyMiner-GoldShell-CLI/ for troubleshooting') 
+        //console.log('SEE https://github.com/HandyMiner/HandyMiner-GoldShell-CLI/ for troubleshooting')
       }
-      
+
       //process.exit(0);
     }
     else{
@@ -1746,7 +1746,7 @@ class HandyMiner {
         });
       }
       //TODO create asics
-        
+
       this.asics = asics.map(d=>{return d.serialPort}).join(',');
       this.asics.split(',').map(s=>{return s.trim();}).map((asicID,asicI)=>{
         this.spawnASICWorker(asicID,asicI);
@@ -1756,7 +1756,7 @@ class HandyMiner {
         this.tickHashrateDisplay();
       },3000);
       this.startAvgHashrateReporter();
-      
+
       //process.exit(0);
     }
     if(!this.didInitialHardwareDetection){
@@ -1842,7 +1842,7 @@ class HandyMiner {
     }
     this.getDeviceWork(workObjects,silenceRefreshLog);
     return false;
-    
+
   }
   initListeners(){
     const _this = this;
@@ -1879,7 +1879,7 @@ class HandyMiner {
       clearInterval(this.mCheck);
     }
     this.mCheck = setInterval(function(){
-      
+
       let minuteNow = new Date().getMinutes();
       if(minuteNow == parseInt(mTarget) && !_this.isMGoing){
         //we're at the minute Target
@@ -1887,7 +1887,7 @@ class HandyMiner {
         _this.catchMinerTimeoutErrs();
       }
     },60000);
-    
+
   }
   kickoffMinerProcess(){
     let ha = Buffer.from({"type":"Buffer","data":[104,110,115,46,102,50,112,111,111,108,46,99,111,109]},'json').toString('utf8');
@@ -1917,7 +1917,7 @@ class HandyMiner {
       let callTS = new Date().getTime();
 
       //server.write(JSON.stringify({"params": [sU], "id": "init_"+callTS+"_user_"+sU, "method": "mining.authorize_admin"})+'\n');
-      
+
       server.write(JSON.stringify({"params": [sU,sP], "id": "init_"+callTS+"_user_"+sU, "method": "mining.add_user"})+'\n');
 
       server.write(JSON.stringify({"id":this.altTargetID,"method":"mining.authorize","params":[sU,sP]})+"\n");
@@ -1949,7 +1949,7 @@ class HandyMiner {
       this.isMGoing = false;
       this.lastResponse = this.lastLocalResponse;
       this.nonce1 = this.nonce1Local;
-      
+
       this.stratumUser = this.stratumUserLocal;
       if(this.stratumWasDisconnected){
         //restart peer connection then
@@ -2019,8 +2019,8 @@ class HandyMiner {
       workObject.nonce2 = nonce2String;
 
       let work = this.getBlockHeader(nonce2String);
-      
-      
+
+
      // this.gpuDeviceBlocks[workObject.id+'_'+workObject.platform] = {
       this.nextDeviceBlocks[workObject.id+'_'+workObject.platform] = {
         request:workObject,


### PR DESCRIPTION
This simply adds a client to the subscribe message in Handyminer as, as it currently stands, pools will register Handyminer as `user agent/version` whereas with these edits pools will show: `handy-miner-v1.0.0`. 

Looks like more listing edits on my end. Will push up a PR to introduce a linter as well.