### PR TITLE
Avoid Make errors

### DIFF
--- a/linux_installation.md
+++ b/linux_installation.md
@@ -7,6 +7,11 @@ sudo apt-get install -y nodejs
 sudo apt-get install alsa-utils
 ```
 
+If Make is not installed, you will not be able to run the npm install command, so run this first
+```
+sudo apt-get install build-essentials
+```
+
 Now that node.js is installed, install the module dependencies for HandyMiner in the HandyMiner-Goldshell-GUI directory
 ```
 npm install


### PR DESCRIPTION
Added a line on make required (at least by Ubuntu 20.10) when installing after your initial build/configure on Ubuntu server/cli.  Note that sudo apt-get install make will leave out a couple of required tools on 20.10 and npm install will still fail.

Feel free to validate, but I think this should help - perhaps add a caveat for Ubuntu if this cannot be reproduced on other flavors of Linux?